### PR TITLE
Add float trap mask to use-foreign-library

### DIFF
--- a/webview.lisp
+++ b/webview.lisp
@@ -37,7 +37,8 @@
   (:windows "webview.dll")
   (t (:default "libwebview")))
 
-(use-foreign-library libwebview)
+(float-features:with-float-traps-masked (:divide-by-zero)
+  (use-foreign-library libwebview))
 
 (defctype webview-t :pointer)
 (defctype webview-error-t :int)


### PR DESCRIPTION
Add with-float-traps-masked around use-foreign-library.
I got a `division-by-zero` error when trying to compile the project, but fixed it by doing this.